### PR TITLE
removing debug step to reduce artifacts retained

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
-          debug: true
+          
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
# Removing debug mode from codeql to reduce storage costs

Artifact storage has hit its limit. We need to turn debug mode off for codeql scanning to avoid running up a bill. 

[PSC-662](https://deliveroo.atlassian.net/browse/PSC-662)

[PSC-662]: https://deliveroo.atlassian.net/browse/PSC-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ